### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,6 @@ This is a plugin for Trunk Recorder that publish the current status over MQTT. E
 ```bash
 git clone https://github.com/eclipse/paho.mqtt.c.git
 cd paho.mqtt.c
-git checkout v1.3.8
 
 cmake -Bbuild -H. -DPAHO_ENABLE_TESTING=OFF -DPAHO_BUILD_STATIC=ON  -DPAHO_WITH_SSL=ON -DPAHO_HIGH_PERFORMANCE=ON
 sudo cmake --build build/ --target install


### PR DESCRIPTION
Remove git checkout command for old release of Paho MQTT C

The directions for building the plugins specifically reference version 1.3.8, but this version has bug that causes messages to persisted to disk, but not be able to be deleted. leading to excessive disk use, and a slow down/hang on restart as the persisted calls are processed again. ref: https://github.com/eclipse/paho.mqtt.c/issues/1035