### PR TITLE
Various additions to plugin

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -134,8 +134,8 @@ find_package(LibHackRF)
 find_package(LibUHD)
 find_package(OpenSSL REQUIRED)
 find_package(CURL REQUIRED)
-find_library(paho-mqttpp3 NAMES libpaho-mqttpp3.a REQUIRED)
-find_library(paho-mqtt3a NAMES libpaho-mqtt3as.a REQUIRED)
+find_library(paho-mqttpp3 NAMES libpaho-mqttpp3.a libpaho-mqttpp3.so REQUIRED)
+find_library(paho-mqtt3a NAMES libpaho-mqtt3as.a libpaho-mqtt3as.so REQUIRED)
 
 ########################################################################
 # Setup boost

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -176,6 +176,7 @@ if(NOT Boost_FOUND)
 endif()
 
 ADD_DEFINITIONS(-DBOOST_ALL_DYN_LINK)
+ADD_DEFINITIONS(-DBOOST_BIND_GLOBAL_PLACEHOLDERS)
 add_definitions(-DGNURADIO_VERSION=${GNURADIO_VERSION})
 
 ########################################################################

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,6 @@
-FROM robotastic/trunk-recorder:latest
+ARG IMAGE=robotastic/trunk-recorder:latest
+
+FROM ${IMAGE}
 
 # Build MQTT Stats
 RUN apt update && export DEBIAN_FRONTEND=noninteractive && \ 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+FROM robotastic/trunk-recorder:latest
+
+# Build MQTT Stats
+RUN apt update && export DEBIAN_FRONTEND=noninteractive && \ 
+    apt install -y libpaho-mqtt-dev libpaho-mqtt1.3  libpaho-mqttpp-dev libpaho-mqttpp3-1  && rm -rf /var/lib/apt/lists/*
+    
+WORKDIR /src/trunk-recorder-mqtt-status
+
+COPY . .
+
+WORKDIR /src/trunk-recorder-mqtt-status/build
+
+RUN cmake .. && make install
+
+WORKDIR /app

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ sudo make install
 | --------- | :------: | ------------- | ------ | ------------------------------------------------------------ |
 | broker    |    ✓     |   tcp://localhost:1883            | string | The URL for the MQTT Message Broker. It should include the protocol used: **tcp**, **ssl**, **ws**, **wss** and the port, which is generally 1883 for tcp, 8883 for ssl, and 443 for ws. |
 | topic     |    ✓     |               | string | This is the base topic to use. The plugin will create subtopics for the different types of status messages. |
+| clientid  |          | tr-status     | string | Sets the MQTT client ID, only needs to be changed if multiple instances are connecting to one MQTT broker. | 
 | username  |          |               | string | If a username is required for the broker, add it here. |
 | password  |          |               | string | If a password is required for the broker, add it here. |
 

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ See the included [config.json](./config.json) as an example of how to load this 
 ```yaml
     "plugins": [
     {
-        "name": "example plugin",
+        "name": "mqtt status",
         "library": "libmqtt_status_plugin.so",
         "broker": "tcp://io.adafruit.com:1883",
         "topic": "robotastic/feeds",
@@ -74,4 +74,27 @@ The Mosquitto MQTT is an easy way to have a local MQTT broker. It can be install
 Starting it on a Mac:
 ```bash
 /opt/homebrew/sbin/mosquitto -c /opt/homebrew/etc/mosquitto/mosquitto.conf
+```
+
+## Docker
+
+The included Dockerfile will allow buliding a trunk-recorder docker image with this plugin included.
+
+`docker-compose` can be used to automate the build and deployment of this image. In the Docker compose file replace the image line with a build line pointing to the location where this repo has been cloned to.   
+
+Docker compose file:
+
+```
+version: '3'
+services:
+  recorder:
+    build: ./trunk-recorder-mqtt-status
+    container_name: trunk-recorder
+    restart: always
+    privileged: true
+    volumes:
+      - /dev/bus/usb:/dev/bus/usb
+      - /var/run/dbus:/var/run/dbus 
+      - /var/run/avahi-daemon/socket:/var/run/avahi-daemon/socket
+      - ./:/app
 ```

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ The included Dockerfile will allow buliding a trunk-recorder docker image with t
 
 Docker compose file:
 
-```
+```yaml
 version: '3'
 services:
   recorder:

--- a/mqtt_status_plugin.cc
+++ b/mqtt_status_plugin.cc
@@ -347,7 +347,7 @@ public:
   {
     const char *LWT_PAYLOAD = "Last will and testament.";
     // set up access channels to only log interesting things
-    client = new mqtt::async_client(this->mqtt_broker, this->clientid, "./store");
+    client = new mqtt::async_client(this->mqtt_broker, this->clientid, config->capture_dir + "/store");
 
     mqtt::connect_options connOpts;
 

--- a/mqtt_status_plugin.cc
+++ b/mqtt_status_plugin.cc
@@ -215,7 +215,7 @@ public:
       root.put("broadcast_signals", this->config->broadcast_signals);
     }
 
-    send_object(root, "config", "config");
+    send_object(root, "config", "config", true);
     m_config_sent = true;
   }
 
@@ -229,7 +229,7 @@ public:
       System *system = *it;
       node.push_back(std::make_pair("", system->get_stats()));
     }
-    return send_object(node, "systems", "systems");
+    return send_object(node, "systems", "systems", true);
   }
 
   int send_system(System *system)
@@ -286,7 +286,7 @@ public:
     return send_object(recorder->get_stats(), "recorder", "recorder");
   }
 
-  int send_object(boost::property_tree::ptree data, std::string name, std::string type)
+  int send_object(boost::property_tree::ptree data, std::string name, std::string type, bool retain = false)
   {
 
     if (m_open == false)
@@ -309,6 +309,7 @@ public:
     {
       mqtt::message_ptr pubmsg = mqtt::make_message(object_topic, stats_str.str());
       pubmsg->set_qos(QOS);
+      pubmsg->set_retained(retain);
       client->publish(pubmsg); //->wait_for(TIMEOUT);
     }
     catch (const mqtt::exception &exc)

--- a/mqtt_status_plugin.cc
+++ b/mqtt_status_plugin.cc
@@ -220,7 +220,7 @@ public:
     // Send the recorders in addition to the config, cause there isn't a better place to do it.
     std::vector<Recorder *> recorders;
 
-    for (std::vector<Source *>::iterator it = this->sources.begin(); it != this->sources.end(); it++) {
+    for (std::vector<Source *>::iterator it = sources.begin(); it != sources.end(); it++) {
       Source *source = *it;
 
       std::vector<Recorder *> sourceRecorders = source->get_recorders();

--- a/mqtt_status_plugin.cc
+++ b/mqtt_status_plugin.cc
@@ -47,6 +47,7 @@ class Mqtt_Status : public Plugin_Api, public virtual mqtt::callback, public vir
   std::string username;
   std::string password;
   std::string topic;
+  std::string clientid;
   mqtt::async_client *client;
 
 protected:
@@ -331,7 +332,7 @@ public:
   {
     const char *LWT_PAYLOAD = "Last will and testament.";
     // set up access channels to only log interesting things
-    client = new mqtt::async_client(this->mqtt_broker, "tr-status", "./store");
+    client = new mqtt::async_client(this->mqtt_broker, this->clientid, "./store");
 
     mqtt::connect_options connOpts;
 
@@ -420,9 +421,13 @@ public:
     BOOST_LOG_TRIVIAL(info) << " MQTT Status Plugin Broker: " << this->mqtt_broker;
     this->topic = cfg.get<std::string>("topic", "");
     BOOST_LOG_TRIVIAL(info) << " MQTT Status Plugin Topic: " << this->topic;
+    this->clientid = cfg.get<std::string>("clientid", "tr-status");
+    BOOST_LOG_TRIVIAL(info) << " MQTT Status Plugin Client ID: " << this->clientid;
     this->username = cfg.get<std::string>("username", "");
     BOOST_LOG_TRIVIAL(info) << " MQTT Status Plugin Broker Username: " << this->username;
     this->password = cfg.get<std::string>("password", "");
+ 
+
 
     return 0;
   }

--- a/mqtt_status_plugin.cc
+++ b/mqtt_status_plugin.cc
@@ -216,6 +216,20 @@ public:
     }
 
     send_object(root, "config", "config", true);
+
+    // Send the recorders in addition to the config, cause there isn't a better place to do it.
+    std::vector<Recorder *> recorders;
+
+    for (std::vector<Source *>::iterator it = this->sources.begin(); it != this->sources.end(); it++) {
+      Source *source = *it;
+
+      std::vector<Recorder *> sourceRecorders = source->get_recorders();
+
+      recorders.insert(recorders.end(), sourceRecorders.begin(), sourceRecorders.end());
+    }
+
+    send_recorders(recorders);
+    
     m_config_sent = true;
   }
 
@@ -265,7 +279,7 @@ public:
       node.push_back(std::make_pair("", recorder->get_stats()));
     }
 
-    return send_object(node, "recorders", "recorders");
+    return send_object(node, "recorders", "recorders",true);
   }
 
   int call_start(Call *call) override


### PR DESCRIPTION
The following changes/improvements are included in this PR:

1. Allow the user to override the default MQTT client id. This is needed when multiple instances are connecting to one MQTT broker.  Having multiple clients with the same id, will cause the clients with the same id to be disconnected form or denied login to the MQTT broker. Also the MQTT standard requires all clients to have a unique ID.
2. Set the retained flag on messages that are only sent on startup(config, systems, and recorders).  This will tell the MQTT broker to retain the last message on each of these topics, so clients can get this information, if they weren't there to receive these messages when trunk-recorder starts up
3. Send the list of all of the recorders.  This brings this plugin more in line with stat_server functionality. 
4. Put the mqtt store folder in the configured captureDir, to allow for the store to be located in a location where disk writes are preferred, such as a ram disk like /dev/shm.
5. Allow building with the shared paho libraries such as those provided in Ubuntu 22
6. Add a Dockerfile to add this plugin to the trunk-recorder docker image.
7. Remove compiler warning based on (https://github.com/robotastic/trunk-recorder/pull/738)